### PR TITLE
Avoid Expand-Archive function clobber; use MS Namespace

### DIFF
--- a/Public/Update-PSRepositoryCache.ps1
+++ b/Public/Update-PSRepositoryCache.ps1
@@ -50,7 +50,7 @@ function Update-PSRepositoryCache {
         #
 
         Write-Log -Message "Expanding archive to $($Config.IndexPath)"
-        Expand-Archive $TP.Index -DestinationPath $Config.IndexPath -Force
+        Microsoft.PowerShell.Archive\Expand-Archive $TP.Index -DestinationPath $Config.IndexPath -Force
         Write-Log -Message "expanded total $((Get-ChildItem $Config.IndexPath).Count) files" # FIXME: This lists also old files from folder
 
         #


### PR DESCRIPTION
Fixes:
	Exception thrown from 'Expand-Archive' if used with PowerShell Community Extensions (Pscx) module. (Probably a good idea to use explicit namespaces for others too.)
Details:
	Pscx's "Expand-Archive" command doesn't have "DestinationPath" parameter and overwrites the default command unless explicit namespace is used or Pscx is loaded with -NoClobber after other modules. (Although I believe this is avoided if strictmode and advanced functions/cmdlets are used, but that would require a lot of work. Also 'Using namespace ....' probably would also work.)

Note: Ignore the no-newline change at bottom, editing file on github site is annoying. (git not installed on this device)